### PR TITLE
fix: print result lines when color is disabled

### DIFF
--- a/seagoat/cli.py
+++ b/seagoat/cli.py
@@ -53,7 +53,10 @@ def print_result_line(result, line, color_enabled):
             f"{result['path']}:{click.style(str(line), bold=True)}:{highlighted_lines[line - 1]}"
         )
     else:
-        print(f"{result['path']}:{line}:{result['line_texts'][line - 1]}")
+        for line_content in result["lines"]:
+            if line_content["line"] == line:
+                print(f"{result['path']}:{line}:{line_content['line_text']}")
+                break
 
 
 @click.command()

--- a/tests/__snapshots__/test_cli.ambr
+++ b/tests/__snapshots__/test_cli.ambr
@@ -5,3 +5,9 @@
   
   '''
 # ---
+# name: test_integration_test_without_color
+  '''
+  file4.js:1:// This is a second updated example JavaScript file
+  
+  '''
+# ---

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,3 +13,14 @@ def test_integration_test_with_color(snapshot, repo, mocker):
 
     assert result.output == snapshot
     assert result.exit_code == 0
+
+
+@pytest.mark.usefixtures("server")
+def test_integration_test_without_color(snapshot, repo, mocker):
+    mocker.patch("os.isatty", return_value=True)
+    runner = CliRunner()
+    query = "JavaScript"
+    result = runner.invoke(seagoat, [query, repo.working_dir, "--no-color"])
+
+    assert result.output == snapshot
+    assert result.exit_code == 0


### PR DESCRIPTION
Seems like something in the data structure changed and the poor color disabled results where ignored.