### PR TITLE
Fix exception in repositories with commits containing ':::' in commit message

### DIFF
--- a/seagoat/repository.py
+++ b/seagoat/repository.py
@@ -9,7 +9,7 @@ from seagoat.file import File
 
 
 def parse_commit_info(raw_line: str):
-    commit_hash, date_str, author, commit_subject = raw_line.split(":::")
+    commit_hash, date_str, author, commit_subject = raw_line.split(":::", 3)
 
     commit_date = datetime.datetime.strptime(date_str, "%Y-%m-%d %H:%M:%S %z").date()
     today = datetime.date.today()

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -85,17 +85,20 @@ def test_commit_messages_with_three_or_more_colons(repo):
     seagoat = Engine(repo.working_dir)
     commit_messages = set()
     for i in range(5):
-        message = "add my file" + ":"*i + "!"
+        message = "add my file" + ":" * i + "!"
         commit_messages.add(message)
         repo.add_file_change_commit(
             file_name="file.txt",
             contents=f"{i}",
             author=repo.actors["John Doe"],
-            commit_message=message
+            commit_message=message,
         )
     seagoat.analyze_codebase()
 
-    assert set(seagoat.repository.get_file("file.txt").commit_messages) == commit_messages
+    assert (
+        set(seagoat.repository.get_file("file.txt").commit_messages) == commit_messages
+    )
+
 
 def test_ignores_certain_branches(repo):
     seagoat = Engine(repo.working_dir)

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -81,6 +81,22 @@ def test_newer_change_can_beat_frequent_change_in_past(repo):
     assert seagoat.repository.top_files()[0][0].path == "new_file.txt"
 
 
+def test_commit_messages_with_three_or_more_colons(repo):
+    seagoat = Engine(repo.working_dir)
+    commit_messages = set()
+    for i in range(5):
+        message = "add my file" + ":"*i + "!"
+        commit_messages.add(message)
+        repo.add_file_change_commit(
+            file_name="file.txt",
+            contents=f"{i}",
+            author=repo.actors["John Doe"],
+            commit_message=message
+        )
+    seagoat.analyze_codebase()
+
+    assert set(seagoat.repository.get_file("file.txt").commit_messages) == commit_messages
+
 def test_ignores_certain_branches(repo):
     seagoat = Engine(repo.working_dir)
     main = repo.active_branch


### PR DESCRIPTION
Setting [maxsplit](https://docs.python.org/3/library/stdtypes.html#str.split).

The following exception was thrown:

```
Exception in thread Thread-1 (_worker_function):
Traceback (most recent call last):
  File "/home/user/.local/pipx/venvs/seagoat/lib/python3.11/site-packages/seagoat/queue/base_queue.py", line 76, in _worker_function
    task = self._task_queue.get(timeout=1)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/queue.py", line 179, in get
    raise Empty
_queue.Empty

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.11/threading.py", line 1038, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.11/threading.py", line 975, in run
    self._target(*self._args, **self._kwargs)
  File "/home/user/.local/pipx/venvs/seagoat/lib/python3.11/site-packages/seagoat/queue/base_queue.py", line 81, in _worker_function
    self.handle_maintenance(context)
  File "/home/user/.local/pipx/venvs/seagoat/lib/python3.11/site-packages/seagoat/queue/task_queue.py", line 50, in handle_maintenance
    remaining_chunks_to_analyze = context["seagoat_engine"].analyze_codebase(
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/.local/pipx/venvs/seagoat/lib/python3.11/site-packages/seagoat/engine.py", line 82, in analyze_codebase
    self.repository.analyze_files()
  File "/home/user/.local/pipx/venvs/seagoat/lib/python3.11/site-packages/seagoat/repository.py", line 46, in analyze_files
    current_commit_info = parse_commit_info(line)
                          ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/.local/pipx/venvs/seagoat/lib/python3.11/site-packages/seagoat/repository.py", line 12, in parse_commit_info
    commit_hash, date_str, author, commit_subject = raw_line.split(":::")
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: too many values to unpack (expected 4)
```