### PR TITLE
test: normalize path in seagoat to support '.'

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -626,3 +626,17 @@ def create_config_file(repo):
     for file_path in created_files:
         if file_path.exists():
             file_path.unlink()
+
+
+@pytest.fixture
+def temporary_cd():
+    @contextmanager
+    def _temporary_cd(path):
+        old_dir = os.getcwd()
+        os.chdir(path)
+        try:
+            yield
+        finally:
+            os.chdir(old_dir)
+
+    return _temporary_cd

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -326,10 +326,11 @@ def test_integration_test_with_color_and_bat(snapshot, repo, mocker, runner, bat
 
 
 @pytest.mark.usefixtures("server", "mock_accuracy_warning")
-def test_integration_test_without_color(snapshot, repo, mocker, runner):
+def test_integration_test_without_color(snapshot, repo, mocker, runner, temporary_cd):
     mocker.patch("os.isatty", return_value=True)
     query = "JavaScript"
-    result = runner.invoke(seagoat, [query, repo.working_dir, "--no-color"])
+    with temporary_cd(repo.working_dir):
+        result = runner.invoke(seagoat, [query, ".", "--no-color"])
 
     assert str(result.output) == snapshot
     assert result.exit_code == 0


### PR DESCRIPTION
tests #125