### PR TITLE
fix : kill the process when stopping server

### DIFF
--- a/seagoat/server.py
+++ b/seagoat/server.py
@@ -20,8 +20,8 @@ from seagoat.utils.server import get_free_port
 from seagoat.utils.server import get_server_info
 from seagoat.utils.server import get_servers_info
 from seagoat.utils.server import is_server_running
-from seagoat.utils.server import stop_server
 from seagoat.utils.server import ServerDoesNotExist
+from seagoat.utils.server import stop_server
 from seagoat.utils.server import update_server_info
 from seagoat.utils.wait import wait_for
 

--- a/seagoat/server.py
+++ b/seagoat/server.py
@@ -20,7 +20,7 @@ from seagoat.utils.server import get_free_port
 from seagoat.utils.server import get_server_info
 from seagoat.utils.server import get_servers_info
 from seagoat.utils.server import is_server_running
-from seagoat.utils.server import remove_server_info
+from seagoat.utils.server import stop_server
 from seagoat.utils.server import ServerDoesNotExist
 from seagoat.utils.server import update_server_info
 from seagoat.utils.wait import wait_for
@@ -193,7 +193,7 @@ def status(repo_path, use_json_format):
 def stop(repo_path):
     """Stops the server."""
     try:
-        remove_server_info(repo_path)
+        stop_server(repo_path)
     except ServerDoesNotExist:
         click.echo(
             f"No server information found for {repo_path}. It might not be running or was never started."

--- a/seagoat/utils/server.py
+++ b/seagoat/utils/server.py
@@ -47,7 +47,6 @@ def get_servers_info() -> Dict[str, ServerInfo]:
 
     return contents
 
-
 def update_server_info(
     repo_path: Union[str, Path], new_server_data: ServerInfo
 ) -> None:
@@ -58,18 +57,18 @@ def update_server_info(
     write_to_json_file(_get_server_data_file_path(), servers_info)
 
 
-def remove_server_info(repo_path: Union[str, Path]) -> None:
+def stop_server(repo_path: Union[str, Path]) -> None:
     servers_info = get_servers_info()
     repo_id = normalize_repo_path(repo_path)
     if repo_id in servers_info:
         server_info = servers_info[repo_id]
         process = psutil.Process(server_info["pid"])
-        
-        process.terminate()
-        process.wait()
 
         servers_info.pop(repo_id)
         write_to_json_file(_get_server_data_file_path(), servers_info)
+
+        process.terminate()
+        process.wait()
     else:
         raise ServerDoesNotExist(f"Server for {repo_path} does not exist.")
 

--- a/seagoat/utils/server.py
+++ b/seagoat/utils/server.py
@@ -28,6 +28,7 @@ def _get_server_data_file_path() -> Path:
     user_cache_dir.mkdir(parents=True, exist_ok=True)
     return user_cache_dir / "serverData.json"
 
+
 def normalize_repo_path(repo_path: Union[str, Path]) -> str:
     return str(os.path.normpath(Path(repo_path).expanduser().resolve()))
 
@@ -46,6 +47,7 @@ def get_servers_info() -> Dict[str, ServerInfo]:
             del contents[key]
 
     return contents
+
 
 def update_server_info(
     repo_path: Union[str, Path], new_server_data: ServerInfo

--- a/seagoat/utils/server.py
+++ b/seagoat/utils/server.py
@@ -6,6 +6,7 @@ from typing import TypedDict
 from typing import Union
 
 import appdirs
+import psutil
 
 from seagoat.utils.json_file import get_json_file_contents
 from seagoat.utils.json_file import write_to_json_file
@@ -26,7 +27,6 @@ def _get_server_data_file_path() -> Path:
     user_cache_dir = Path(appdirs.user_cache_dir("seagoat-servers"))
     user_cache_dir.mkdir(parents=True, exist_ok=True)
     return user_cache_dir / "serverData.json"
-
 
 def normalize_repo_path(repo_path: Union[str, Path]) -> str:
     return str(os.path.normpath(Path(repo_path).expanduser().resolve()))
@@ -62,6 +62,12 @@ def remove_server_info(repo_path: Union[str, Path]) -> None:
     servers_info = get_servers_info()
     repo_id = normalize_repo_path(repo_path)
     if repo_id in servers_info:
+        server_info = servers_info[repo_id]
+        process = psutil.Process(server_info["pid"])
+        
+        process.terminate()
+        process.wait()
+
         servers_info.pop(repo_id)
         write_to_json_file(_get_server_data_file_path(), servers_info)
     else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -249,10 +249,16 @@ def real_chromadb():
     chromadb_patcher.start()
 
 
+def _get_multiprocessing_context():
+    if os.name == "nt":
+        return multiprocessing.get_context("spawn")
+    return multiprocessing.get_context("forkserver")
+
+
 @pytest.fixture(name="start_server")
 def _start_server(repo):
     def _start():
-        context = multiprocessing.get_context("forkserver")
+        context = _get_multiprocessing_context()
         server_process = context.Process(
             target=start_server, args=(repo.working_dir,), daemon=True
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -248,13 +248,17 @@ def real_chromadb():
     yield
     chromadb_patcher.start()
 
+def _start_forked_server(repo):
+    if os.fork() != 0: 
+        return 
+    start_server(repo) 
 
 @pytest.fixture(name="start_server")
 def _start_server(repo):
     def _start():
         context = multiprocessing.get_context("spawn")
         server_process = context.Process(
-            target=start_server, args=(repo.working_dir,), daemon=True
+            target=_start_forked_server, args=(repo.working_dir,), daemon=True
         )
         server_process.start()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -248,10 +248,12 @@ def real_chromadb():
     yield
     chromadb_patcher.start()
 
+
 def _start_forked_server(repo):
     if os.fork() != 0:
         return
     start_server(repo)
+
 
 @pytest.fixture(name="start_server")
 def _start_server(repo):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -249,18 +249,12 @@ def real_chromadb():
     chromadb_patcher.start()
 
 
-def _start_forked_server(repo):
-    if os.fork() != 0:
-        return
-    start_server(repo)
-
-
 @pytest.fixture(name="start_server")
 def _start_server(repo):
     def _start():
-        context = multiprocessing.get_context("spawn")
+        context = multiprocessing.get_context("forkserver")
         server_process = context.Process(
-            target=_start_forked_server, args=(repo.working_dir,), daemon=True
+            target=start_server, args=(repo.working_dir,), daemon=True
         )
         server_process.start()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -249,9 +249,9 @@ def real_chromadb():
     chromadb_patcher.start()
 
 def _start_forked_server(repo):
-    if os.fork() != 0: 
-        return 
-    start_server(repo) 
+    if os.fork() != 0:
+        return
+    start_server(repo)
 
 @pytest.fixture(name="start_server")
 def _start_server(repo):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -140,8 +140,8 @@ def test_stop(repo):
         text=True,
         check=False,
     )
-    assert result.returncode == 0
     assert not psutil.pid_exists(server_info["pid"])
+    assert result.returncode == 0
     assert "Server is not running" in result.stdout
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -126,6 +126,8 @@ def test_status_2(repo):
 
 @pytest.mark.usefixtures("server")
 def test_stop(repo):
+    server_info = get_server_info(repo.working_dir)
+
     subprocess.run(
         ["python", "-m", "seagoat.server", "stop", repo.working_dir],
         capture_output=True,
@@ -139,6 +141,7 @@ def test_stop(repo):
         check=False,
     )
     assert result.returncode == 0
+    assert not psutil.pid_exists(server_info["pid"])
     assert "Server is not running" in result.stdout
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -128,6 +128,8 @@ def test_status_2(repo):
 def test_stop(repo):
     server_info = get_server_info(repo.working_dir)
 
+    assert psutil.pid_exists(server_info["pid"])
+
     subprocess.run(
         ["python", "-m", "seagoat.server", "stop", repo.working_dir],
         capture_output=True,


### PR DESCRIPTION
Fixes #210

I've modified first `test_stop` to check if the server is stopped, and it failed. Then I modified `stop_server` (previously `remove_server_info`) to `terminate` and `wait` the server process. Now the test passes.

Note : I have modified `_start_server` from `tests/conftest.py` file to detach the server process from the test process. If I don't do that `wait` function hangs on because it waits for the server process (which is also the same as the test) to terminate. 

Not sure to be 100% clear, I'm new in python. Don't hesitate to ask any question. Also I'd be happy to get some feedback if you have some. Thanks!