### PR TITLE
first cut at llama.cpp encoding

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -584,6 +584,17 @@ files = [
 graph = ["objgraph (>=1.7.2)"]
 
 [[package]]
+name = "diskcache"
+version = "5.6.3"
+description = "Disk Cache -- Disk and file backed persistent cache."
+optional = false
+python-versions = ">=3"
+files = [
+    {file = "diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19"},
+    {file = "diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc"},
+]
+
+[[package]]
 name = "distlib"
 version = "0.3.7"
 description = "Distribution utilities"
@@ -1126,6 +1137,27 @@ files = [
 
 [package.dependencies]
 referencing = ">=0.28.0"
+
+[[package]]
+name = "llama-cpp-python"
+version = "0.2.11"
+description = "Python bindings for the llama.cpp library"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "llama_cpp_python-0.2.11.tar.gz", hash = "sha256:aae4820bb24aca61800bac771fb735dcc22b08c1374300782ab47eb65743723a"},
+]
+
+[package.dependencies]
+diskcache = ">=5.6.1"
+numpy = ">=1.20.0"
+typing-extensions = ">=4.5.0"
+
+[package.extras]
+all = ["llama_cpp_python[dev,server,test]"]
+dev = ["black (>=23.3.0)", "httpx (>=0.24.1)", "mkdocs (>=1.4.3)", "mkdocs-material (>=9.1.18)", "mkdocstrings[python] (>=0.22.0)", "pytest (>=7.4.0)", "twine (>=4.0.2)"]
+server = ["fastapi (>=0.100.0)", "pydantic-settings (>=2.0.1)", "sse-starlette (>=1.6.1)", "starlette-context (>=0.3.6,<0.4)", "uvicorn (>=0.22.0)"]
+test = ["httpx (>=0.24.1)", "pytest (>=7.4.0)"]
 
 [[package]]
 name = "markdown"
@@ -3374,4 +3406,4 @@ watchdog = ["watchdog (>=2.3)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c9a4b9e824ba115e5e48c2316f00ca9a8e2e7c8a1c1fcf31896a7a1edfa486c9"
+content-hash = "8f8e24cbae0a800cc1192aa8c879419391a55ab0ce4fa82b51c273c825db54fa"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ chardet = "^5.2.0"
 pyyaml = "^6.0.1"
 jsonschema = "^4.19.1"
 deepmerge = "^1.1.0"
+llama-cpp-python = "^0.2.11"
 
 [virtualenvs]
 in-project = true

--- a/seagoat/engine.py
+++ b/seagoat/engine.py
@@ -67,8 +67,8 @@ class Engine:
             },
         )
         self.cache.load()
-        self.repository = Repository(path)
         self.config = get_config_values(Path(path))
+        self.repository = Repository(path, self.config["server"]["model_path"])
 
         self._fetchers = {
             "async": [

--- a/seagoat/repository.py
+++ b/seagoat/repository.py
@@ -19,10 +19,11 @@ def parse_commit_info(raw_line: str):
 
 
 class Repository:
-    def __init__(self, repo_path: str):
+    def __init__(self, repo_path: str, model_path: str = None):
         self.path = Path(repo_path)
         self.file_changes = defaultdict(list)
         self.frecency_scores = {}
+        self.model_path = model_path
 
     def analyze_files(self):
         cmd = [
@@ -71,7 +72,6 @@ class Repository:
             self.frecency_scores[file] = score
 
     def top_files(self):
-        print("Got top files from", self.frecency_scores)
         return [
             (self.get_file(filename), score)
             for filename, score in sorted(

--- a/seagoat/repository.py
+++ b/seagoat/repository.py
@@ -48,9 +48,13 @@ class Repository:
                     filename = line
 
                     if not is_file_type_supported(filename):
+                        print(f"Skipping {filename} because it is not supported")
                         continue
 
                     if not (self.path / filename).exists():
+                        print(
+                            f"Skipping {self.path/filename} because it does not exist"
+                        )
                         continue
 
                     self.file_changes[filename].append(current_commit_info)
@@ -67,6 +71,7 @@ class Repository:
             self.frecency_scores[file] = score
 
     def top_files(self):
+        print("Got top files from", self.frecency_scores)
         return [
             (self.get_file(filename), score)
             for filename, score in sorted(

--- a/seagoat/sources/chroma.py
+++ b/seagoat/sources/chroma.py
@@ -20,6 +20,7 @@ def initialize(repository: Repository):
         model_path="/Users/alecf/github/llama.cpp/models/codellama-7b-instruct.Q5_K_M.gguf",
         n_ctx=2048,
         embedding=True,
+        n_gpu_layers=1,
     )
 
     def llama_embed(inputs: List[str]):
@@ -36,7 +37,6 @@ def initialize(repository: Repository):
         print("Produced embeddings of length ", [len(s) for s in result])
         return result
 
-    print("Cache folder in ", cache.get_cache_folder())
     chroma_client = chromadb.PersistentClient(
         path=str(cache.get_cache_folder()),
         settings=Settings(

--- a/seagoat/utils/config.py
+++ b/seagoat/utils/config.py
@@ -25,6 +25,7 @@ CONFIG_SCHEMA = {
             "properties": {
                 "port": {"type": "integer", "minimum": 1, "maximum": 65535},
                 "ignorePatterns": {"type": "array", "items": {"type": "string"}},
+                "model_path": {"type": "string"},
             },
         },
         "client": {


### PR DESCRIPTION
NOTE: This is not ready to be merged but I wanted to share in case anyone wants to help with this

SeaGOAT is pretty cool but I've been disappointed by the results.. so I thought I'd try using codellama for embeddings, using llama_cpp_python

It works reasonably well with a few caveats:
1) embedding without GPU is *slow* - initially it was like 7-10s per chunk on my M2 mac, but once you turn on GPU support it is more like 300ms. I haven't tried on an Intel machine or with a non-metal GPU
2) you need to download a llama model an set up your .seagoat.yml to point to the model:

  ```yaml
  server:
    model_path: "/path/to/codellama-7b-instruct.Q5_K_M.gguf"
  ```
3) I think the chunking could also be improved by doing some kind of syntactic/hierarchical chunking, but that is pretty slow too... however I wonder if bigger chunks might actually be better here. (because I think embedding fragments of source probably loses a lot of semantic information)