### PR TITLE
Fix check for updates failure message

### DIFF
--- a/seagoat/cli.py
+++ b/seagoat/cli.py
@@ -162,7 +162,6 @@ def seagoat(
         display_results(results, max_results, color_enabled)
 
         display_accuracy_warning(server_address)
-        warn_if_update_available()
     except (
         requests.exceptions.ConnectionError,
         requests.exceptions.RequestException,
@@ -174,6 +173,13 @@ def seagoat(
             f"seagoat-server start {repo_path}\n"
         )
         sys.exit(ExitCode.SERVER_NOT_RUNNING)
+
+    try:
+        warn_if_update_available()
+    except requests.exceptions.ConnectionError:
+        click.echo(
+            "Could not check for updates because the pypi.org API is not accessible"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently if there is no internet seagoat will say that the server is not running, which might or might not be true.

This fixes that.