### PR TITLE
Fix git --object-only usage

### DIFF
--- a/seagoat/repository.py
+++ b/seagoat/repository.py
@@ -49,10 +49,9 @@ class Repository:
                 "ls-tree",
                 "HEAD",
                 str(file_path),
-                "--object-only",
             ],
             text=True,
-        ).strip()
+        ).split()[2].strip()
 
         return object_id
 


### PR DESCRIPTION
I don't have such in my git 2.34.1, so I had to fix it in an obvious way