### PR TITLE
Replace unpinned actions with pinned action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,37 +1,36 @@
----
 name: docs deployment to github pages
 on:
-    push:
-        branches:
-            - main
+  push:
+    branches:
+      - main
 permissions:
-    contents: write
+  contents: write
 jobs:
-    deploy:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-              with:
-                  fetch-depth: 0 # fetch all history for all branches and tags
-            - uses: actions/setup-python@v5
-              with:
-                  python-version: 3.11
-            - name: Install Poetry
-              uses: snok/install-poetry@v1
-            - name: Install dependencies
-              run: poetry install --no-interaction --no-root
-            - name: Install Mike
-              run: poetry run pip install mike
-            - name: Configure git
-              run: |
-                  git config --global user.name "GitHub Actions"
-                  git config --global user.email "actions@github.com"
-            - name: Fetch all history for all branches and tags
-              run: git fetch --all
-            - name: Deploy docs with Mike
-              run: |
-                  VERSION=$(poetry run semantic-release --noop version --print)
-                  # Remove patch version and replace it with 'x'
-                  VERSION="${VERSION%.*}.x"
-                  poetry run mike deploy --push --update-aliases $VERSION latest
-                  poetry run mike set-default --push latest
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          fetch-depth: 0 # fetch all history for all branches and tags
+      - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5
+        with:
+          python-version: 3.11
+      - name: Install Poetry
+        uses: snok/install-poetry@93ada01c735cc8a383ce0ce2ae205a21c415379b # v1
+      - name: Install dependencies
+        run: poetry install --no-interaction --no-root
+      - name: Install Mike
+        run: poetry run pip install mike
+      - name: Configure git
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+      - name: Fetch all history for all branches and tags
+        run: git fetch --all
+      - name: Deploy docs with Mike
+        run: |
+          VERSION=$(poetry run semantic-release --noop version --print)
+          # Remove patch version and replace it with 'x'
+          VERSION="${VERSION%.*}.x"
+          poetry run mike deploy --push --update-aliases $VERSION latest
+          poetry run mike set-default --push latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,38 +1,30 @@
----
 name: lint and other checks
-
 on:
-    push:
-        branches: [main]
-    pull_request:
-        branches: [main]
-
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 jobs:
-    build:
-        defaults:
-            run:
-                shell: bash
-        runs-on: ${{ matrix.os }}
-        strategy:
-            matrix:
-                os: [ubuntu-latest]
-                python-version: ['3.11']
-
-        steps:
-            - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-
-            - name: Set up Python
-              id: setup-python
-              uses: actions/setup-python@v5
-              with:
-                  python-version: ${{ matrix.python-version }}
-
-            - name: Install Poetry
-              uses: snok/install-poetry@v1
-
-            - name: Install dependencies
-              run: poetry install --no-interaction --no-root
-
-            - name: Run pre-commit
-              run: |
-                  poetry run pre-commit run --all-files
+  build:
+    defaults:
+      run:
+        shell: bash
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ['3.11']
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - name: Set up Python
+        id: setup-python
+        uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Poetry
+        uses: snok/install-poetry@93ada01c735cc8a383ce0ce2ae205a21c415379b # v1
+      - name: Install dependencies
+        run: poetry install --no-interaction --no-root
+      - name: Run pre-commit
+        run: |
+          poetry run pre-commit run --all-files

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,72 +1,61 @@
----
 name: Semantic Release
-
 permissions:
-    id-token: write
-    contents: write
-
+  id-token: write
+  contents: write
 on:
-    push:
-        branches:
-            - main
-
+  push:
+    branches:
+      - main
 jobs:
-    release:
-        defaults:
-            run:
-                shell: bash
-        runs-on: ubuntu-latest
-        concurrency: release
-
-        steps:
-            - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-              with:
-                  fetch-depth: 0
-
-            - name: release
-              id: release
-              uses: python-semantic-release/python-semantic-release@v9.1.1
-              with:
-                  github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-
-            - name: update latest tag
-              # NOTE: DO NOT wrap the conditional in ${{ }} as it will always evaluate to true.
-              # See https://github.com/actions/runner/issues/1173
-              if: steps.release.outputs.released == 'true'
-              run: |
-                  git config user.email "git@daniel-kantor.com"
-                  git config user.name "github-actions"
-                  git tag -fa latest -m "Update to latest version"
-                  git push origin :refs/tags/latest
-                  git push origin --tags
-
-            - name: publish to pypi
-              uses: pypa/gh-action-pypi-publish@release/v1
-              # NOTE: DO NOT wrap the conditional in ${{ }} as it will always evaluate to true.
-              # See https://github.com/actions/runner/issues/1173
-              if: steps.release.outputs.released == 'true'
-
-            - name: Clone AUR package
-              run: git clone https://aur.archlinux.org/python-seagoat.git
-
-            - name: Update PKGBUILD
-              run: |
-                  ls
-                  VERSION=$(grep "^version =" pyproject.toml | sed 's/version = "\(.*\)"/\1/')
-                  echo $VERSION
-                  sed -i "s/pkgver=.*/pkgver=$VERSION/g" python-seagoat/PKGBUILD
-                  cat python-seagoat/PKGBUILD
-
-            - name: Publish AUR package
-              uses: KSXGitHub/github-actions-deploy-aur@v2.7.0
-              # NOTE: DO NOT wrap the conditional in ${{ }} as it will always evaluate to true.
-              # See https://github.com/actions/runner/issues/1173
-              if: steps.release.outputs.released == 'true'
-              with:
-                  pkgname: python-seagoat
-                  pkgbuild: ./python-seagoat/PKGBUILD
-                  commit_username: ${{ secrets.AUR_USERNAME }}
-                  commit_email: ${{ secrets.AUR_EMAIL }}
-                  ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
-                  commit_message: Update AUR package
-                  ssh_keyscan_types: rsa,dsa,ecdsa,ed25519
+  release:
+    defaults:
+      run:
+        shell: bash
+    runs-on: ubuntu-latest
+    concurrency: release
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          fetch-depth: 0
+      - name: release
+        id: release
+        uses: python-semantic-release/python-semantic-release@79ee9a95ef0415a8bad2aa6006ec33abe4f81b69 # v9.1.1
+        with:
+          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      - name: update latest tag
+        # NOTE: DO NOT wrap the conditional in ${{ }} as it will always evaluate to true.
+        # See https://github.com/actions/runner/issues/1173
+        if: steps.release.outputs.released == 'true'
+        run: |
+          git config user.email "git@daniel-kantor.com"
+          git config user.name "github-actions"
+          git tag -fa latest -m "Update to latest version"
+          git push origin :refs/tags/latest
+          git push origin --tags
+      - name: publish to pypi
+        uses: pypa/gh-action-pypi-publish@81e9d935c883d0b210363ab89cf05f3894778450 # release/v1
+        # NOTE: DO NOT wrap the conditional in ${{ }} as it will always evaluate to true.
+        # See https://github.com/actions/runner/issues/1173
+        if: steps.release.outputs.released == 'true'
+      - name: Clone AUR package
+        run: git clone https://aur.archlinux.org/python-seagoat.git
+      - name: Update PKGBUILD
+        run: |
+          ls
+          VERSION=$(grep "^version =" pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          echo $VERSION
+          sed -i "s/pkgver=.*/pkgver=$VERSION/g" python-seagoat/PKGBUILD
+          cat python-seagoat/PKGBUILD
+      - name: Publish AUR package
+        uses: KSXGitHub/github-actions-deploy-aur@063daf78a56662642bb00049ce78425ff6d0fad7 # v2.7.0
+        # NOTE: DO NOT wrap the conditional in ${{ }} as it will always evaluate to true.
+        # See https://github.com/actions/runner/issues/1173
+        if: steps.release.outputs.released == 'true'
+        with:
+          pkgname: python-seagoat
+          pkgbuild: ./python-seagoat/PKGBUILD
+          commit_username: ${{ secrets.AUR_USERNAME }}
+          commit_email: ${{ secrets.AUR_EMAIL }}
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          commit_message: Update AUR package
+          ssh_keyscan_types: rsa,dsa,ecdsa,ed25519

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,64 +1,53 @@
----
 name: pytest
-
 on:
-    push:
-        branches: [main]
-    pull_request:
-        branches: [main]
-
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 jobs:
-    build:
-        defaults:
-            run:
-                shell: bash
-        runs-on: ${{ matrix.os }}
-        strategy:
-            matrix:
-                os: [ubuntu-latest]
-                python-version: ['3.11']
-
-        steps:
-            - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-
-            - name: Set up Python
-              id: setup-python
-              uses: actions/setup-python@v5
-              with:
-                  python-version: ${{ matrix.python-version }}
-
-            - name: Install ripgrep
-              run: |
-                  if [ "${{ matrix.os }}" == "ubuntu-latest" ]; then
-                    curl -LO https://github.com/BurntSushi/ripgrep/releases/download/13.0.0/ripgrep_13.0.0_amd64.deb
-                    sudo dpkg -i ripgrep_13.0.0_amd64.deb
-                  elif [ "${{ matrix.os }}" == "windows-latest" ]; then
-                    choco install ripgrep
-                  elif [ "${{ matrix.os }}" == "macos-latest" ]; then
-                    brew install ripgrep
-                  fi
-
-            - name: Install Poetry
-              uses: snok/install-poetry@v1
-
-            - name: Install dependencies on macOS
-              if: runner.os == 'macOS'
-              run: |
-                  export HNSWLIB_NO_NATIVE=1
-                  arch -x86_64 poetry install --no-interaction --no-root
-
-            - name: Install dependencies on other OS
-              if: runner.os != 'macOS'
-              run: |
-                  export HNSWLIB_NO_NATIVE=1
-                  poetry install --no-interaction --no-root
-
-            - name: Run pytest
-              run: |
-                  poetry run pytest . -vvs --timeout=300 --cov seagoat --cov-report=xml
-
-            - name: Upload coverage reports to Codecov
-              uses: codecov/codecov-action@v4-beta
-              if: matrix.os == 'ubuntu-latest'
-              env:
-                  CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  build:
+    defaults:
+      run:
+        shell: bash
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ['3.11']
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - name: Set up Python
+        id: setup-python
+        uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install ripgrep
+        run: |
+          if [ "${{ matrix.os }}" == "ubuntu-latest" ]; then
+            curl -LO https://github.com/BurntSushi/ripgrep/releases/download/13.0.0/ripgrep_13.0.0_amd64.deb
+            sudo dpkg -i ripgrep_13.0.0_amd64.deb
+          elif [ "${{ matrix.os }}" == "windows-latest" ]; then
+            choco install ripgrep
+          elif [ "${{ matrix.os }}" == "macos-latest" ]; then
+            brew install ripgrep
+          fi
+      - name: Install Poetry
+        uses: snok/install-poetry@93ada01c735cc8a383ce0ce2ae205a21c415379b # v1
+      - name: Install dependencies on macOS
+        if: runner.os == 'macOS'
+        run: |
+          export HNSWLIB_NO_NATIVE=1
+          arch -x86_64 poetry install --no-interaction --no-root
+      - name: Install dependencies on other OS
+        if: runner.os != 'macOS'
+        run: |
+          export HNSWLIB_NO_NATIVE=1
+          poetry install --no-interaction --no-root
+      - name: Run pytest
+        run: |
+          poetry run pytest . -vvs --timeout=300 --cov seagoat --cov-report=xml
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@428cda1b1c731be3e8bfa389049c3f276d572ffb # v4-beta
+        if: matrix.os == 'ubuntu-latest'
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
<!-- minder: pr-remediation-body: { "ContentSha": "a0faf4c5e78e76ede1ca31b4a0881a55b7c44a10" } -->

This is a Minder automated pull request.

This pull request replaces references to actions by tag to references to actions by SHA.

Verifies that any actions use pinned tags
Pinning an action to a full length commit SHA is currently the only way to use
an action as an immutable release. Pinning to a particular SHA helps mitigate
the risk of a bad actor adding a backdoor to the action's repository, as they
would need to generate a SHA-1 collision for a valid Git object payload.
When selecting a SHA, you should verify it is from the action's repository
and not a repository fork.

For more information, see
https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
