### PR TITLE
Update GitHub Actions tags to digests

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,11 +13,11 @@ jobs:
             - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
               with:
                   fetch-depth: 0 # fetch all history for all branches and tags
-            - uses: actions/setup-python@v5
+            - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5
               with:
                   python-version: 3.11
             - name: Install Poetry
-              uses: snok/install-poetry@v1
+              uses: snok/install-poetry@93ada01c735cc8a383ce0ce2ae205a21c415379b # v1
             - name: Install dependencies
               run: poetry install --no-interaction --no-root
             - name: Install Mike

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,12 +23,12 @@ jobs:
 
             - name: Set up Python
               id: setup-python
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5
               with:
                   python-version: ${{ matrix.python-version }}
 
             - name: Install Poetry
-              uses: snok/install-poetry@v1
+              uses: snok/install-poetry@93ada01c735cc8a383ce0ce2ae205a21c415379b # v1
 
             - name: Install dependencies
               run: poetry install --no-interaction --no-root

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
 
             - name: release
               id: release
-              uses: python-semantic-release/python-semantic-release@v9.1.1
+              uses: python-semantic-release/python-semantic-release@79ee9a95ef0415a8bad2aa6006ec33abe4f81b69 # v9.1.1
               with:
                   github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
@@ -41,7 +41,7 @@ jobs:
                   git push origin --tags
 
             - name: publish to pypi
-              uses: pypa/gh-action-pypi-publish@release/v1
+              uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0 # release/v1
               # NOTE: DO NOT wrap the conditional in ${{ }} as it will always evaluate to true.
               # See https://github.com/actions/runner/issues/1173
               if: steps.release.outputs.released == 'true'
@@ -58,7 +58,7 @@ jobs:
                   cat python-seagoat/PKGBUILD
 
             - name: Publish AUR package
-              uses: KSXGitHub/github-actions-deploy-aur@v2.7.0
+              uses: KSXGitHub/github-actions-deploy-aur@063daf78a56662642bb00049ce78425ff6d0fad7 # v2.7.0
               # NOTE: DO NOT wrap the conditional in ${{ }} as it will always evaluate to true.
               # See https://github.com/actions/runner/issues/1173
               if: steps.release.outputs.released == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
 
             - name: Set up Python
               id: setup-python
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5
               with:
                   python-version: ${{ matrix.python-version }}
 
@@ -39,7 +39,7 @@ jobs:
                   fi
 
             - name: Install Poetry
-              uses: snok/install-poetry@v1
+              uses: snok/install-poetry@93ada01c735cc8a383ce0ce2ae205a21c415379b # v1
 
             - name: Install dependencies on macOS
               if: runner.os == 'macOS'
@@ -58,7 +58,7 @@ jobs:
                   poetry run pytest . -vvs --timeout=300 --cov seagoat --cov-report=xml
 
             - name: Upload coverage reports to Codecov
-              uses: codecov/codecov-action@v4-beta
+              uses: codecov/codecov-action@428cda1b1c731be3e8bfa389049c3f276d572ffb # v4-beta
               if: matrix.os == 'ubuntu-latest'
               env:
                   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Digests are considered more secure, as it fixes the action to a specific commit

Check out [GitHubs documentation](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
for more information on why this is important.

You already have dependabot enabled, all future updates will be pinned to digests :rocket:

I generated this change using [Frizbee](https://github.com/stacklok/frizbee),
an open source tool that flips tags to digests in Dockerfiles and GitHub Actions.

I created a second PR that add's the Frizbee action to the repository,
which will flip any future tags to digests automatically.
