### PR TITLE
fix: fix git --object-only usage

### DIFF
--- a/seagoat/repository.py
+++ b/seagoat/repository.py
@@ -41,18 +41,21 @@ class Repository:
         Returns the git object id for the current version
         of a file
         """
-        object_id = subprocess.check_output(
-            [
-                "git",
-                "-C",
-                str(self.path),
-                "ls-tree",
-                "HEAD",
-                str(file_path),
-                "--object-only",
-            ],
-            text=True,
-        ).strip()
+        object_id = (
+            subprocess.check_output(
+                [
+                    "git",
+                    "-C",
+                    str(self.path),
+                    "ls-tree",
+                    "HEAD",
+                    str(file_path),
+                ],
+                text=True,
+            )
+            .split()[2]
+            .strip()
+        )
 
         return object_id
 


### PR DESCRIPTION
I don't have such in my git 2.34.1, so I had to fix it in an obvious way

style: apply auto-formatting to the code