### PR TITLE
Grammar Error: Spacing error in Hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,7 @@ gt "Where are the numbers rounded"
 ```
 
 You can also use
-[Regular Expressions](https://en.wikipedia.org/wiki/Regular_expression)
-in your queries, for example
+[Regular Expressions](https://en.wikipedia.org/wiki/Regular_expression) in your queries, for example
 
 ```bash
 gt "function calc_.* that deals with taxes"


### PR DESCRIPTION
Grammar error in spacing of hyperlink of " [Expressions](https://en.wikipedia.org/wiki/Regular_expression)in ".
Changed "Expressionsin" into "Expressions in"