### PR TITLE
Add an option to limit maximum commits used for frecency

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,6 +25,9 @@ This is an example of a configuration file:
 
 server:
   port: 31134  # A port number to run the server on
+  # Increase number of commits used for computing frecency score
+  # Default is `1000`, set to `null` to read all history
+  readMaxCommits: 5000
 
   # globs to ignore in addition to .gitignore
   ignorePatterns:

--- a/seagoat/repository.py
+++ b/seagoat/repository.py
@@ -92,6 +92,9 @@ class Repository:
             "--no-merges",
         ]
 
+        if (max_commits := self.config["server"]["readMaxCommits"]) is not None:
+            cmd.append(f"--max-count={max_commits}")
+
         self.file_changes.clear()
 
         files = set(

--- a/seagoat/repository.py
+++ b/seagoat/repository.py
@@ -90,10 +90,8 @@ class Repository:
             "--name-only",
             "--pretty=format:###%h:::%ai:::%an <%ae>:::%s",
             "--no-merges",
+            *self._git_log_extra_options(),
         ]
-
-        if (max_commits := self.config["server"]["readMaxCommits"]) is not None:
-            cmd.append(f"--max-count={max_commits}")
 
         self.file_changes.clear()
 
@@ -121,6 +119,14 @@ class Repository:
                     self.file_changes[filename].append(current_commit_info)
 
         self._compute_frecency()
+
+    def _git_log_extra_options(self):
+        cmd = []
+
+        if (max_commits := self.config["server"]["readMaxCommits"]) is not None:
+            cmd.append(f"--max-count={max_commits}")
+
+        return cmd
 
     def _compute_frecency(self):
         self.frecency_scores = {}

--- a/seagoat/utils/config.py
+++ b/seagoat/utils/config.py
@@ -13,7 +13,7 @@ DEFAULT_CONFIG = {
     "server": {
         "port": None,
         "ignorePatterns": [],
-        "readMaxCommits": 1000,
+        "readMaxCommits": 5_000,
         "chroma": {
             "embeddingFunction": {
                 "name": "DefaultEmbeddingFunction",

--- a/seagoat/utils/config.py
+++ b/seagoat/utils/config.py
@@ -13,6 +13,7 @@ DEFAULT_CONFIG = {
     "server": {
         "port": None,
         "ignorePatterns": [],
+        "readMaxCommits": 1000,
         "chroma": {
             "embeddingFunction": {
                 "name": "DefaultEmbeddingFunction",
@@ -35,6 +36,11 @@ CONFIG_SCHEMA = {
             "additionalProperties": False,
             "properties": {
                 "port": {"type": "integer", "minimum": 1, "maximum": 65535},
+                "readMaxCommits": {
+                    "type": ["integer", "null"],
+                    "minimum": 1,
+                    "maximum": 65535,
+                },
                 "ignorePatterns": {
                     "type": "array",
                     "items": {"type": "string"},


### PR DESCRIPTION
This adds an option to limit number of processed commits for frecency.

We use number instead of date, because it works the same for both active and not very active repos.

Refs #711