### PR TITLE
Fix stale git file handling and document macOS install

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,27 @@ To install SeaGOAT using `pipx`, use the following command:
 pipx install seagoat
 ```
 
+#### macOS
+
+On macOS, the recommended setup is Homebrew plus `pipx`:
+
+```bash
+brew install pipx ripgrep bat
+pipx ensurepath
+pipx install seagoat
+```
+
+Then start the server from a Git repository and query it:
+
+```bash
+seagoat-server start /path/to/your/repo
+gt "Where is authentication handled?"
+```
+
+`bat` is optional, but recommended for highlighted output. If you prefer Conda,
+create a Python 3.11+ environment, install `ripgrep` and `bat`, then run
+`pip install seagoat` inside that environment.
+
 ### System requirements
 
 #### Hardware
@@ -49,7 +70,7 @@ Should work on any decent laptop.
 #### Operating system
 
 SeaGOAT is designed to work on Linux (*tested* ✅),
-macOS ([partly tested, **help**](https://github.com/kantord/SeaGOAT/issues/178) 🙏)
+macOS (*community-tested on Apple Silicon and Intel* ✅)
 and Windows ([**help needed**](https://github.com/kantord/SeaGOAT/issues/179) 🙏).
 
 ### Start SeaGOAT server

--- a/seagoat/repository.py
+++ b/seagoat/repository.py
@@ -50,21 +50,21 @@ class Repository:
         Returns the git object id for the current version
         of a file
         """
-        object_id = (
-            subprocess.check_output(
-                [
-                    "git",
-                    "-C",
-                    str(self.path),
-                    "ls-tree",
-                    "HEAD",
-                    str(file_path),
-                ],
-                text=True,
-            )
-            .split()[2]
-            .strip()
+        output = subprocess.check_output(
+            [
+                "git",
+                "-C",
+                str(self.path),
+                "ls-tree",
+                "HEAD",
+                str(file_path),
+            ],
+            text=True,
         )
+        parts = output.split()
+        if len(parts) < 3:
+            raise FileNotFoundError(f"file is not present in HEAD: {file_path}")
+        object_id = parts[2].strip()
 
         return object_id
 
@@ -75,7 +75,10 @@ class Repository:
         return autodecode_bytes(data)
 
     def is_up_to_date_git_object(self, file_path: str, git_object_id: str):
-        return self.get_file_object_id(file_path) == git_object_id
+        try:
+            return self.get_file_object_id(file_path) == git_object_id
+        except FileNotFoundError:
+            return False
 
     def get_status_hash(self):
         combined = self._get_head_hash() + self._get_working_tree_diff()
@@ -138,12 +141,16 @@ class Repository:
             self.frecency_scores[file] = score
 
     def top_files(self):
-        return [
-            (self.get_file(filename), score)
-            for filename, score in sorted(
-                self.frecency_scores.items(), key=lambda x: x[0][1]
-            )
-        ]
+        top_files = []
+        for filename, score in sorted(
+            self.frecency_scores.items(), key=lambda x: x[0][1]
+        ):
+            try:
+                top_files.append((self.get_file(filename), score))
+            except FileNotFoundError:
+                continue
+
+        return top_files
 
     def get_file(self, filename: str):
         """

--- a/seagoat/sources/chroma.py
+++ b/seagoat/sources/chroma.py
@@ -44,7 +44,10 @@ def format_results(query_text: str, repository, chromadb_results):
         if not repository.is_up_to_date_git_object(path, git_object_id):
             continue
 
-        gitfile = repository.get_file(path)
+        try:
+            gitfile = repository.get_file(path)
+        except FileNotFoundError:
+            continue
 
         if path not in files:
             files[path] = Result(query_text, gitfile)

--- a/seagoat/sources/ripgrep.py
+++ b/seagoat/sources/ripgrep.py
@@ -136,7 +136,10 @@ def initialize(repository: Repository):
         for line in rg_output.splitlines():
             relative_path, raw_line_number, _ = line.split(":", 2)
             line_number = int(raw_line_number)
-            gitfile = repository.get_file(relative_path)
+            try:
+                gitfile = repository.get_file(relative_path)
+            except FileNotFoundError:
+                continue
 
             if not is_file_type_supported(relative_path):
                 continue

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -267,6 +267,27 @@ def test_does_not_crash_because_of_non_existent_files(repo):
     }
 
 
+def test_top_files_skips_stale_entries_not_present_in_head(repo):
+    seagoat = Engine(repo.working_dir)
+    seagoat.analyze_codebase()
+    seagoat.repository.frecency_scores["missing.cc"] = 999
+
+    assert "missing.cc" not in {
+        file.path for file, _ in seagoat.repository.top_files()
+    }
+
+
+def test_missing_file_object_id_is_clear_and_not_index_error(repo):
+    seagoat = Engine(repo.working_dir)
+
+    try:
+        seagoat.repository.get_file_object_id("missing.cc")
+    except FileNotFoundError as exc:
+        assert "missing.cc" in str(exc)
+    else:
+        raise AssertionError("expected missing git object to raise FileNotFoundError")
+
+
 def test_ignored_files_is_really_ignored(repo: MockRepo):
     file_name = "node_modules/acorn/README.md"
     repo.add_file_change_commit(


### PR DESCRIPTION
## What changed

This is a small pass on the macOS support issue (#178):

- add the Homebrew + `pipx` install path that people in the thread confirmed works
- update the README wording from “partly tested/help” to community-tested on Apple Silicon and Intel
- avoid the reported `IndexError` when SeaGOAT has a stale cached/frecency/ripgrep/chroma path that is no longer present in `HEAD`

The code fix keeps stale files out of result/cache paths instead of letting an empty `git ls-tree` result crash `Repository.get_file_object_id()`.

## Authorship / support note

Co-authored by Srinji <srinji@logicalworks.ca> and Codex <codex@logicalworks.ca> / <codex@openai.com>.

Codex is an AI coding assistant supporting the LogicalWorks agentic development workflow. SeaGOAT has been useful as local semantic code-search infrastructure for that workflow, so this is a small upstream support contribution: document the macOS path people already validated, and fix the stale-file crash reported by macOS users in the issue thread.

## Testing

Poetry is not installed in my local environment, so I ran the targeted tests through a temporary `uv` environment:

```bash
uv run --with pytest --with pytest-mock --with freezegun --with gitpython --with appdirs --with orjson --with requests --with pyyaml --with click --with chromadb --with tqdm --with stop-words --with flask --with waitress --with chardet --with jsonschema --with deepmerge --with blessed --with pygments --with nest-asyncio --with psutil --with halo --with ollama --with mcp --with pytest-timeout --with pytest-asyncio --with syrupy python -m pytest tests/test_repository.py tests/test_source_ripgrep.py -q
```

Result: `23 passed, 1 warning`.

Also ran `git diff --check`.
